### PR TITLE
ci: add skill-review GitHub Action for automated skill review on PRs

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,13 @@
+name: Skill Review
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead # main


### PR DESCRIPTION
Hey @inyhow 👋

Thanks for merging #2. The SKILL.md improvements are live and looking clean.

Since the repo already has a build workflow for releases, I thought it'd be useful to add a quality gate specifically for skill file changes. This wires up the same `tessl skill review` tool from #2 as a GitHub Action.

## What this adds

A single workflow file: `.github/workflows/skill-review.yml`

It runs `tessl skill review` whenever a PR touches `**/SKILL.md` and posts a score card as a PR comment. No secrets to configure. Works out of the box with the default `GITHUB_TOKEN`.

## Permissions & trust

The workflow requests two permissions:

| Permission | Why | Scope |
|---|---|---|
| `contents: read` | Checkout the PR branch to read SKILL.md files | Read-only |
| `pull-requests: write` | Post the score card as a PR comment | Write, scoped to the triggering PR only |

The action is pinned to a specific commit SHA (`tesslio/skill-review@22e928d...`), not a mutable tag. So what you review now is exactly what runs in CI. No silent updates.

## How it fits

| Workflow | Trigger | Purpose |
|---|---|---|
| `build.yml` (existing) | Tag push `v*` | Build and release |
| `skill-review.yml` (new) | PR touching `**/SKILL.md` | Automated skill quality gate |

---

Same disclosure as #2. I work at [[@tesslio](https://github.com/tesslio)](https://github.com/tesslio). This is the same tool that generated the improvements in #2, just wired up to run automatically on future changes.

Thanks 🙏